### PR TITLE
Changed Party Parrot as a Service link to UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -123,7 +123,7 @@
           <a class="button-small" href="https://github.com/jmhobbs/terminal-parrot">Terminal</a>
           <a class="button-small" href="https://github.com/Shrugs/partyparrot">Text-To-Parrots</a>
           <a class="button-small" href="http://countryparrots.com/">Country Parrots</a>
-          <a class="button-small" href="https://github.com/francoislg/PPaaS">Party Parrot as a Service</a>
+          <a class="button-small" href="https://parrotify.github.io/">Party Parrot as a Service</a>
         </p>
         
         <hr/>


### PR DESCRIPTION
Instead of linking to the GitHub repo, linking to the UI to create Party Parrots (with approval from original creator of PPaaS)