### PR TITLE
Add link to PartyParrots on MacBook Touch Bar

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -132,6 +132,10 @@
           <a class="button-small" href="https://parrotify.github.io/">Party Parrot as a Service</a>
           <a class="button-small" href="https://www.reddit.com/r/PartyParrot">r/PartyParrot</a>
         </p>
+
+        <p>
+          <a class="button-small" href="https://github.com/mjaniszew/osx-touchbar-party-parrot">PartyParrot on MacBook's Touch Bar</a>
+        </p>
         
         <hr/>
         


### PR DESCRIPTION
Hi,

Because we need Party Parrots everywhere, I've came up with an idea to use MacBook's fancy Touch Bar for serious cause, and I've created simple app which displays Party Parrots over there: https://github.com/mjaniszew/osx-touchbar-party-parrot 

![party-touchbar-preview](https://cloud.githubusercontent.com/assets/701365/23940948/24ef0cae-0967-11e7-9d56-80e2537a5565.gif)

This PR contains link to it if you're willing to add it.