### PR TITLE
Add --guests option to upload party guests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ installed to run this:
  
  The following are optional args you can append to 3. above: 
  1. `--google` Use this if your Slack team uses Google signin
+ 2. `--guests` Use this to invite all the party guests
 
  __Notice__: The uploader won't re-write already existing parrots if they match by name.
 

--- a/upload_parrots.py
+++ b/upload_parrots.py
@@ -88,6 +88,8 @@ def main():
                         help='The slack password with which to login')
     parser.add_argument('--google', action='store_true',
                         help='Only add this arg if you use Google signin for your Slack team')
+    parser.add_argument('--guests', action='store_true',
+                        help='Also upload guests to the party')
 
     args = parser.parse_args()
 
@@ -95,6 +97,10 @@ def main():
     dir_path = os.path.dirname(os.path.realpath(__file__))
     all_the_parrots = glob.glob(os.path.join(dir_path, 'parrots/hd/*.gif'))
     all_the_parrots += glob.glob(os.path.join(dir_path, 'parrots/*.gif'))
+    if (args.guests):
+        all_the_parrots += glob.glob(os.path.join(dir_path, 'guests/hd/*.gif'))
+        all_the_parrots += glob.glob(os.path.join(dir_path, 'guests/*.gif'))
+
     try:
         uploader.login(args.username, args.password, args.google)
         for parrot in all_the_parrots:


### PR DESCRIPTION
Before this change, we were leaving out all the party guests from the party. This allows us to upload all the guests with the `--guests` flag.