### PR TITLE
Update permissions test.

### DIFF
--- a/test/permissions.js
+++ b/test/permissions.js
@@ -2,10 +2,13 @@ var fs        = require('fs'),
     assert    = require('chai').assert;
 
 
-var RWRR = parseInt("100644", 8);
-
 function modeString(mode) {
  return '0' + (mode & 0777).toString(8);
+}
+
+// Return true if a mode doesn't have any execute bits.
+function modeNoExecute(mode) {
+  return 0 == (mode & 0111);
 }
 
 describe("gifs", function() {
@@ -16,12 +19,12 @@ describe("gifs", function() {
 
         parrot_hd_gifs.forEach(function(gif) {
             var mode = fs.statSync(__dirname + '/../parrots/hd/' + gif).mode;
-            assert(mode == RWRR, gif + " has bad permissions, " + modeString(mode));
+            assert(modeNoExecute(mode), gif + " has bad permissions, " + modeString(mode));
         });
 
         guests_hd_gifs.forEach(function(gif) {
             var mode = fs.statSync(__dirname + '/../guests/hd/' + gif).mode;
-            assert(mode == RWRR, gif + " has bad permissions, " + modeString(mode));
+            assert(modeNoExecute(mode), gif + " has bad permissions, " + modeString(mode));
         });
     });
 
@@ -32,13 +35,13 @@ describe("gifs", function() {
         parrot_gifs.forEach(function(gif) {
             if(gif == "hd") { return; }
             var mode = fs.statSync(__dirname + '/../parrots/' + gif).mode;
-            assert(mode == RWRR, gif + " has bad permissions, " + modeString(mode));
+            assert(modeNoExecute(mode), gif + " has bad permissions, " + modeString(mode));
         });
 
         guests_gifs.forEach(function(gif) {
             if(gif == "hd") { return; }
             var mode = fs.statSync(__dirname + '/../guests/' + gif).mode;
-            assert(mode == RWRR, gif + " has bad permissions, " + modeString(mode));
+            assert(modeNoExecute(mode), gif + " has bad permissions, " + modeString(mode));
         });
     });
 });


### PR DESCRIPTION
Git only tracks the execute bit, testing for other permissions is invalid.

> In this case, you’re specifying a mode of 100644, which means it’s a normal file.
> Other options are 100755, which means it’s an executable file; and 120000, which
> specifies a symbolic link. The mode is taken from normal UNIX modes but is much
> less flexible — these three modes are the only ones that are valid for files
> (blobs) in Git (although other modes are used for directories and submodules).

[1] https://git-scm.com/docs/git-update-index#git-update-index---chmod-x
[2] https://git-scm.com/book/en/v2/Git-Internals-Git-Objects

Closes #268 and #269 