### PR TITLE
Add emacs parrot to list of parrot tools

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -168,6 +168,7 @@
           <a class="button-small" href="https://twitter.com/hugojmd/status/937997911257882624"><tt>curl parrot.live</tt></a>
           <a class="button-small" href="https://t.me/PartyParrotBot">Telegram Bot</a>
           <a class="button-small" href="https://www.npmjs.com/package/parrotify-cli">parrotify-cli</a>
+          <a class="button-small" href="https://github.com/dp12/parrot">emacs parrot</a>
         </p>
 
         <hr/>


### PR DESCRIPTION
Emacs now supports showing the parrot in the mode-line bar, when parrot-mode is enabled