### PR TITLE
Fix a typo :partyparrot:

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
       ``+mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmhooh
 ```
 
-The only Slack reaction gif's you'll ever need.
+The only Slack reaction gifs you'll ever need.
 
 ## Thanks
 


### PR DESCRIPTION
Just a quick typo fix - more than one `gif` is `gifs`