### PR TITLE
Updated Discord Bot's Demo Server's invite link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -173,7 +173,7 @@
         <small>A bot to add some parrots to your server!</small>
         <p>
           <a class="button-small" href="https://github.com/Kizzaris/partydiscord">Bot Code</a>
-          <a class="button-small" href="https://discord.gg/BG3AUfh">Demo Server</a>
+          <a class="button-small" href="https://discord.gg/HCDQfqm">Demo Server</a>
           <a class="button-small" href="https://discordapp.com/oauth2/authorize?client_id=394830082058747905&permissions=1074006016&scope=bot">Mr. Parrot Invite Link</a>
         </p>
 


### PR DESCRIPTION
The old invite link was revoked today, because it's been used to add spambot's to the server.