### PR TITLE
Update parrot.css

### DIFF
--- a/src/parrot.css
+++ b/src/parrot.css
@@ -271,7 +271,6 @@ aside {
 
 li > span {
   color: #444;
-  cursor: pointer;
   position: relative;
 }
 


### PR DESCRIPTION
Removing cursor from li>span because it's not necessary and unhelpful from an usability and accessibility perspective. It indicates interactivity on an element that isn't interactive.