### PR TITLE
Replace deprecated <tt> html tag with <code>

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -188,7 +188,7 @@
           <a class="button-small" href="https://github.com/matheuss/parrotsay">Parrot Say</a>
           <a class="button-small" href="https://codepen.io/nathangath/pen/RgvzVY/">CSS Parrot</a>
           <a class="button-small" href="https://github.com/breadadams/fetch-the-parrot">Fetch-the-parrot</a>
-          <a class="button-small" href="https://twitter.com/hugojmd/status/937997911257882624"><tt>curl parrot.live</tt></a>
+          <a class="button-small" href="https://twitter.com/hugojmd/status/937997911257882624"><code>curl parrot.live</code></a>
           <a class="button-small" href="https://t.me/PartyParrotBot">Telegram Bot</a>
           <a class="button-small" href="https://www.npmjs.com/package/parrotify-cli">parrotify-cli</a>
           <a class="button-small" href="https://github.com/dp12/parrot">emacs parrot</a>


### PR DESCRIPTION
HTML `<tt>` tag is deprecated and could be removed at any time, [source]( https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt).

`<code>` tag is supported by all major browsers, [source](https://www.w3schools.com/tags/tag_code.asp)