### PR TITLE
Add shellcheck to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,10 @@
 version: 2.1
 orbs:
   node: circleci/node@3.0.0
+  shellcheck: circleci/shellcheck@2.0.0
 workflows:
-  node-tests:
+  build:
     jobs:
       - node/test
+      - shellcheck/check:
+          pattern: "make"


### PR DESCRIPTION
Add the shellcheck orb to make sure the `make` script is sound.