### PR TITLE
Fix the GitHub link pointing to the bot's source code

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -174,7 +174,7 @@
         <h3>Discord</h3>
         <small>A bot to add some parrots to your server!</small>
         <p>
-          <a class="button-small" href="https://github.com/Kizzaris/partydiscord">Bot Code</a>
+          <a class="button-small" href="https://github.com/Kalolol/partydiscord">Bot Code</a>
           <a class="button-small" href="https://discord.gg/HCDQfqm">Demo Server</a>
           <a class="button-small" href="https://discordapp.com/oauth2/authorize?client_id=394830082058747905&permissions=1074006016&scope=bot">Mr. Parrot Invite Link</a>
         </p>


### PR DESCRIPTION
Things added/changed:

- Fix the GitHub link pointing to the bot's source code
  - When I clicked on the link, it landed me on a 404 page. I did a quick search at GitHub, and I think I found the correct [repository](https://github.com/Kalolol/partydiscord).
