### PR TITLE
Small 'hd' logo going over popin (added z-index)

### DIFF
--- a/src/parrot.css
+++ b/src/parrot.css
@@ -297,7 +297,8 @@ li > span {
   top: 0px;
 }
 [tooltip]:hover:before {
-  opacity : 1;
+  opacity: 1;
+  z-index: 1;
 }
 
 h3 {


### PR DESCRIPTION
Hey!

I'm happy to make this huge contribution to this amazing repo.

| Before | After |
|-|-|
| ![Before](https://i.imgur.com/OLTRKKF.png) | ![After](https://i.imgur.com/s2Lg2eN.png) |

_(Notice the small colored 'hd' going over the black popin between lines 2 and 3)_

Thanks and have a nice day <img src="https://cultofthepartyparrot.com/parrots/hd/parrot.gif" height="32" width="32" />.