### PR TITLE
Adds updated keyboard for iOS

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -158,7 +158,7 @@
 
         <h3>Keyboards!</h3>
         <div class="clearfix keyboards">
-          <a href="https://apps.apple.com/us/app/cult-of-the-party-parrot/id1169278591"><img src="/assets/app-store-badge.svg" alt="Download on the App Store" /></a>
+          <a href="https://apps.apple.com/us/app/party-parrots-hd/id1635466234"><img src="/assets/app-store-badge.svg" alt="Download on the App Store" /></a>
           <a href="https://play.google.com/store/apps/details?id=us.fetch321.partyparrotkeyboard"><img src="/assets/google-play-badge.svg" alt="Download on Google Play" /></a>
         </div>
 


### PR DESCRIPTION
I created a new free Party Parrot iOS keyboard.

The one currently linked has not been updated since 2016 and has roughly 40, none HD stickers.
https://apps.apple.com/us/app/cult-of-the-party-parrot/id1169278591

My new keyboard has over 170 HD parrots that are indeed partying.
https://apps.apple.com/us/app/party-parrots-hd/id1635466234

<img width="1043" alt="Screenshot 2023-01-11 at 9 00 48 PM" src="https://user-images.githubusercontent.com/16943514/211972787-aa4fdc62-f5bd-4126-9a53-1b05e3aa8854.png">

Party or die.